### PR TITLE
extended .newItem behaviour

### DIFF
--- a/knockoutFire.js
+++ b/knockoutFire.js
@@ -168,8 +168,8 @@ ko.extenders.firebaseArray = function(self, options) {
                     childNames.forEach(function(childName, i) {
                         self.newItem[childName]("");
                     });
-                    if ( typeof(map[".newItem"][".create_success"]) == "function" ) {
-                        map[".newItem"][".autofocus"]() ;
+                    if ( typeof(map[".newItem"][".on_success"]) == "function" ) {
+                        map[".newItem"][".on_success"]() ;
                     }
                 }
             };


### PR DESCRIPTION
Hi, i added 2 features to the create function: 
- its now possible to define default-values for items. 
- on can call some function .on_success, eg. to set focus on fields. 

see it working here: 
http://jsfiddle.net/ayurmedia/ycpMD/

i forked and cloned your example. 
