### PR TITLE
Fixed item being added to wrong end of collection

### DIFF
--- a/knockoutFire.js
+++ b/knockoutFire.js
@@ -75,9 +75,9 @@ ko.extenders.firebaseArray = function(self, options) {
             self.splice(reverse ? index : index + 1, 0, child);
         } else {
             if (reverse) {
-                self.unshift(child);
-            } else {
                 self.push(child);
+            } else {
+                self.unshift(child);
             }
         }
     };


### PR DESCRIPTION
When previous item is null, a new item should be added to the beginning of a collection, or unshifted, rather than pushed to the end (vice-versa in reverse mode).
