### PR TITLE
i made a small modification for loading data, when attributes are missing in firebase objects. 

### DIFF
--- a/knockoutFire.js
+++ b/knockoutFire.js
@@ -144,9 +144,6 @@ ko.extenders.firebaseArray = function(self, options) {
                     // try defaults
                     if (typeof(map[".newItem"][childName]) == "function") {
                         var defaultValue = map[".newItem"][childName]();
-                        if (typeof(val) != "object") {
-                            val = {"val": val};
-                        }
                         val[childName] = defaultValue;
                     } else {
                         val[childName] = self.newItem[childName]();
@@ -204,6 +201,9 @@ ko.extenders.firebasePrimitive = function(self, options) {
 
 */
 ko.extenders.firebase = function(self, options) {
+    // if database is missing an attribute we continue
+    if( typeof self() == 'null' || options.map == true ) return; 
+    
     var firebase = options.firebaseRef;
     self.firebase = firebase;
     self().firebase = firebase;


### PR DESCRIPTION
when changing your schema of object. eg. adding a field/attribute, then the knockoutFire function exits with error, because the "map" cannot be matched with the data coming from the database. 
with this   

if( typeof self() == 'null' || options.map == true ) return; 

it will still work, and one can read and write data.

you can see demo at: 
http://www.holomind.de/todos/

eg. i changed my objects to also have attribute "user": 
-ItIOcbx80cg-gxTdvkQ

```
content: some text
isdone: 1
project: project-1
user: user1
```

-ItIOeW3u0KdUKtGD_1C

```
content: other test
isdone: 0
project: project-1
```

=> here the user: user-1 is missing, and had caused problems before. 
with this extra line it works. and data can be loaded and saved, and the missing values will be added automatically. 
